### PR TITLE
Refactor WriteTo method

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,11 +20,6 @@ linters:
   disable:
     - errcheck
 
-linters-settings:
-  govet:
-    disable:
-      -  stdmethods
-
 issues:
   exclude-use-default: false
   exclude:

--- a/internal/writer.go
+++ b/internal/writer.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"io"
+)
+
+// WriteCounter defines a struct which collects write counts of
+// a giving io.Writer
+type WriteCounter struct {
+	io.Writer
+	written int64
+}
+
+// NewWriteCounter returns a new instance of the WriteCounter.
+func NewWriteCounter(w io.Writer) *WriteCounter {
+	return &WriteCounter{Writer: w}
+}
+
+// Written returns the total number of data writer to the underline writer.
+func (w *WriteCounter) Written() int64 {
+	return w.written
+}
+
+// Write calls the internal io.Writer.Write method and adds up
+// the write counts.
+func (w *WriteCounter) Write(data []byte) (int, error) {
+	inc, err := w.Writer.Write(data)
+
+	w.written += int64(inc)
+
+	return inc, err
+}

--- a/sshconfig_test.go
+++ b/sshconfig_test.go
@@ -71,6 +71,56 @@ func TestFindByHostname(t *testing.T) {
 	assert.Equal(t, devHost.String(), devHostBlockTest)
 }
 
+func TestWriteTo(t *testing.T) {
+	config, err := Parse(strings.NewReader(sshConfigTest))
+
+	assert.NoError(t, err)
+
+	var b bytes.Buffer
+
+	writtenCount, err := config.WriteTo(&b)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, sshConfigTest, b.String())
+	assert.Equal(t, writtenCount, int64(156))
+}
+
+func TestWriteToWithNewParam(t *testing.T) {
+	config, err := Parse(strings.NewReader(sshConfigTest))
+
+	host := config.FindByHostname("dev")
+	param := host.GetParam("User")
+	param.Args = []string{"ec2-user"}
+
+	assert.NoError(t, err)
+
+	var b bytes.Buffer
+
+	writtenCount, err := config.WriteTo(&b)
+
+	assert.NoError(t, err)
+
+	expected := `
+# global configuration
+VisualHostKey yes
+
+# host-based configuration
+
+# dev
+Host dev
+  HostName 127.0.0.1
+  User ec2-user
+  Port 22
+
+Host *.google.com *.yahoo.com
+  User root
+`
+
+	assert.Equal(t, expected, b.String())
+	assert.Equal(t, writtenCount, int64(158))
+}
+
 func TestWriteToFilepath(t *testing.T) {
 	config, err := Parse(strings.NewReader(sshConfigTest))
 


### PR DESCRIPTION
* If we’re using writeTo, we should follow convention…
* And it makes `go vet` happier:
```
method WriteTo(w io.Writer) error should have signature WriteTo(io.Writer) (int64, error)
```
* Create a writer helper package to do most of the counting work for us
* Adds testing around writeTo